### PR TITLE
Add metrics prefix

### DIFF
--- a/internal/ctlog/cmd/rome2024h1/main.go
+++ b/internal/ctlog/cmd/rome2024h1/main.go
@@ -55,7 +55,7 @@ func main() {
 		NotAfterStart: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC),
 		NotAfterLimit: time.Date(2024, time.July, 1, 0, 0, 0, 0, time.UTC),
 	}
-
+	metricsPrefix := flag.String("metricsPrefix", "litetlog_", "String value to preface all metrics with e.g. litetlog_<metric>")
 	createFlag := flag.Bool("create", false, "create the log")
 	flag.Parse()
 	if *createFlag {
@@ -70,9 +70,12 @@ func main() {
 	}
 
 	metrics := prometheus.NewRegistry()
-	prometheus.WrapRegistererWith(prometheus.Labels{
-		"log": "rome2024h1",
-	}, metrics).MustRegister(l.Metrics()...)
+	prometheus.WrapRegistererWith(
+		prometheus.Labels{
+			"log": "rome2024h1",
+		},
+		prometheus.WrapRegistererWithPrefix(*metricsPrefix, metrics),
+	).MustRegister(l.Metrics()...)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/debug/pprof/", pprof.Index)


### PR DESCRIPTION
Adds a new command line flag `-metricsPrefix` so that all metrics can be namespaced and therefore easily discovered.

```
$ curl -Lk https://127.0.0.1:8443/metrics
# HELP litelog_in_flight_requests 
# TYPE litelog_in_flight_requests gauge
litetlog_in_flight_requests{endpoint="add-chain",log="rome2024h1"} 0
litetlog_in_flight_requests{endpoint="add-pre-chain",log="rome2024h1"} 0
```