### PR TITLE
bastion: Close backend connections on failure

### DIFF
--- a/bastion/bastion.go
+++ b/bastion/bastion.go
@@ -173,7 +173,23 @@ func (p *backendConnectionsPool) RoundTrip(r *http.Request) (*http.Response, err
 		// TODO: return this as a response instead.
 		return nil, errors.New("backend unavailable")
 	}
-	return cc.RoundTrip(r)
+	rsp, err := cc.RoundTrip(r)
+	if err != nil {
+		// Disconnect and forget this backend.
+		p.Lock()
+		if p.conns[keyHash(kh)] == cc {
+			delete(p.conns, keyHash(kh))
+		}
+		p.Unlock()
+		if !cc.State().Closed {
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+				defer cancel()
+				cc.Shutdown(ctx)
+			}()
+		}
+	}
+	return rsp, err
 }
 
 func (p *backendConnectionsPool) handleBackend(hs *http.Server, c *tls.Conn, h http.Handler) {


### PR DESCRIPTION
This change aims to close backend connections whenever its Roundtrip method fails.

Please have a look if it makes sense; I'm not familiar with the related http and http2 packages.